### PR TITLE
I added some functions to gdevices_sycl.hpp

### DIFF
--- a/Nwpw/nwpwlib/device/gdevices_sycl.hpp
+++ b/Nwpw/nwpwlib/device/gdevices_sycl.hpp
@@ -218,22 +218,24 @@ class Gdevices {
 
    oneapi::mkl::transpose matT = oneapi::mkl::transpose::trans;
    oneapi::mkl::transpose matN = oneapi::mkl::transpose::nontrans;
- 
+   oneapi::mkl::transpose matC = oneapi::mkl::transpose::conjtrans;
+
+
    /* device, host pool memory */
    std::map<size_t, std::set<double *>> free_list_gpu, free_list_host;
    std::map<double *, size_t> live_ptrs_gpu, live_ptrs_host;
- 
+
    int fftcount = 0;
    desc_real_t *desc_x[2];
    desc_cmplx_t *desc_y[2], *desc_z[2];
- 
+
    sycl::event h2d_event, fftevent, d2h_event;
 
 public:
    bool hasgpu = true;
- 
+
    std::vector<sycl::queue *> stream;
- 
+
    /* device memory */
    int ndev_mem = 0;
    bool inuse[NDEV_MAX] = {false};
@@ -244,15 +246,15 @@ public:
    int tile_npack2[19], tile_start2[19];
    double *a_psi, *a_hpsi, *b_prj;
    int ia_psi[2], ia_hpsi[2], ib_prj[2];
- 
+
    int ifft_dev[15];
    int ifft_n;
- 
+
    /* constructor */
    Gdevices() {
      if (DEBUG_IO) std::cout << "calling gdevices constructor" << std::endl;
      ndev_mem = 0;
- 
+
      auto asyncHandler = [&](sycl::exception_list eL) {
        for (auto &e : eL) {
          try {
@@ -264,41 +266,41 @@ public:
          }
        }
      };
- 
+
      // allocate SYCL streams
- 
+
      for (auto i=0; i<12; ++i) {
        stream.push_back(new sycl::queue(
            sycl::gpu_selector_v, asyncHandler,
            sycl::property_list{sycl::property::queue::in_order{}}));
      }
- 
+
    }
- 
+
    /* deconstructor */
    ~Gdevices() {
- 
+
      // free dev_mem
      for (auto i=0; i<ndev_mem; ++i)
        sycl::free(dev_mem[i], *stream[0]);
      ndev_mem = 0;
- 
+
      // free cuda streams
      for (auto i=0; i<12; ++i)
        delete stream[i];
    }
- 
-   int fetch_dev_mem_indx(const size_t ndsize) 
+
+   int fetch_dev_mem_indx(const size_t ndsize)
    {
       int ii = 0;
       while ((((ndsize != ndsize_mem[ii]) || inuse[ii])) && (ii < ndev_mem))
          ++ii;
-     
-      if (ii < ndev_mem) 
+
+      if (ii < ndev_mem)
       {
          inuse[ii] = true;
-      } 
-      else 
+      }
+      else
       {
          ii = ndev_mem;
          inuse[ii] = true;
@@ -307,11 +309,11 @@ public:
          ndev_mem += 1;
          if (ndev_mem>NDEV_MAX) std::cout << "ERROR: ndev_mem > NDEV_MAX" << std::endl;
       }
-     
+
       stream[0]->memset(dev_mem[ii], 0, ndsize * sizeof(double)).wait();
       return ii;
    }
- 
+
    /**************************************
     *                                    *
     *              TN4_dgemm             *
@@ -319,12 +321,12 @@ public:
     **************************************/
    /* This function computes <host_a|host_a>, <host_a|host_b>, <host_b|host_a>,
       and <host_b|host_b> overlap matrices.
- 
+
        host_caa = beta*host_caa + alpha*host_a'*host_a
        host_cab = beta*host_cab + alpha*host_a'*host_b
        host_cba = beta*host_cba + alpha*host_b'*host_a
        host_cbb = beta*host_cbb + alpha*host_b'*host_b
- 
+
       Entry - npack2,ne: matrix size
               alpha, beta: standard dgemm parameters
               host_a: (npack2xne) matrix
@@ -336,20 +338,20 @@ public:
    */
    void TN4_dgemm(int npack2, int ne, double alpha, double *host_a,
                   double *host_b, double beta, double *host_caa,
-                  double *host_cab, double *host_cba, double *host_cbb) 
+                  double *host_cab, double *host_cba, double *host_cbb)
    {
       int ic11 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
       int ic12 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
       int ic21 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
       int ic22 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
-     
+
       if (std::fabs(beta) > 0.0) {
         stream[0]->memcpy(dev_mem[ic11], host_caa, ne * ne * sizeof(double));
         stream[0]->memcpy(dev_mem[ic12], host_cab, ne * ne * sizeof(double));
         stream[0]->memcpy(dev_mem[ic21], host_cba, ne * ne * sizeof(double));
         stream[0]->memcpy(dev_mem[ic22], host_cbb, ne * ne * sizeof(double));
       }
-     
+
       // copy host_a,host_b --> dev_mem
       syclSetMatrixAsync(tile_npack2[0], ne, sizeof(double),
                          &host_a[tile_start2[0]], npack2, dev_mem[ia_psi[0]],
@@ -357,12 +359,12 @@ public:
       syclSetMatrixAsync(tile_npack2[0], ne, sizeof(double),
                          &host_b[tile_start2[0]], npack2, dev_mem[ia_hpsi[0]],
                          tile_npack2[0], stream[0]);
-     
+
       double beta0 = beta;
-      for (auto tt = 0; tt < tile_fac; ++tt) 
+      for (auto tt = 0; tt < tile_fac; ++tt)
       {
          int ttp1 = tt + 1;
-         if (ttp1 < tile_fac) 
+         if (ttp1 < tile_fac)
          {
             syclSetMatrixAsync(tile_npack2[ttp1], ne, sizeof(double),
                                &host_a[tile_start2[ttp1]], npack2,
@@ -374,7 +376,7 @@ public:
                                stream[ttp1 % 2]);
          }
          stream[tt % 2]->wait();
-        
+
          oneapi::mkl::blas::column_major::gemm(
              *stream[tt % 2], matT, matN, ne, ne, tile_npack2[tt], alpha,
              dev_mem[ia_psi[tt % 2]], tile_npack2[tt], dev_mem[ia_psi[tt % 2]],
@@ -393,20 +395,20 @@ public:
              tile_npack2[tt], beta0, dev_mem[ic22], ne);
          beta0 = 1.0;
       }
-     
+
       stream[0]->memcpy(host_caa, dev_mem[ic11], ne * ne * sizeof(double));
       stream[0]->memcpy(host_cab, dev_mem[ic12], ne * ne * sizeof(double));
       stream[0]->memcpy(host_cba, dev_mem[ic21], ne * ne * sizeof(double));
       stream[0]->memcpy(host_cbb, dev_mem[ic22], ne * ne * sizeof(double));
-     
+
       stream[0]->wait();
-     
+
       inuse[ic11] = false;
       inuse[ic12] = false;
       inuse[ic21] = false;
       inuse[ic22] = false;
    }
- 
+
    /**************************************
     *                                    *
     *              TN3_dgemm             *
@@ -414,11 +416,11 @@ public:
     **************************************/
    /* This function computes <host_a|host_a>, <host_a|host_b>, and
       <host_b|host_b> overlap matrices.
- 
+
        host_caa = beta*host_caa + alpha*host_a'*host_a
        host_cab = beta*host_cab + alpha*host_a'*host_b
        host_cbb = beta*host_cbb + alpha*host_b'*host_b
- 
+
       Entry - npack2,ne: matrix size
               alpha, beta: standard dgemm parameters
               host_a: (npack2xne) matrix
@@ -430,19 +432,19 @@ public:
    */
    void TN3_dgemm(int npack2, int ne, double alpha, double *host_a,
                   double *host_b, double beta, double *host_caa,
-                  double *host_cab, double *host_cbb) 
+                  double *host_cab, double *host_cbb)
    {
       int ic11 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
       int ic12 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
       int ic22 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
-     
-      if (std::fabs(beta) > 0.0) 
+
+      if (std::fabs(beta) > 0.0)
       {
          stream[0]->memcpy(dev_mem[ic11], host_caa, ne * ne * sizeof(double));
          stream[0]->memcpy(dev_mem[ic12], host_cab, ne * ne * sizeof(double));
          stream[0]->memcpy(dev_mem[ic22], host_cbb, ne * ne * sizeof(double));
       }
-     
+
       // copy host_a,host_b --> dev_mem
       syclSetMatrixAsync(tile_npack2[0], ne, sizeof(double),
                          &host_a[tile_start2[0]], npack2, dev_mem[ia_psi[0]],
@@ -450,9 +452,9 @@ public:
       syclSetMatrixAsync(tile_npack2[0], ne, sizeof(double),
                          &host_b[tile_start2[0]], npack2, dev_mem[ia_hpsi[0]],
                          tile_npack2[0], stream[0]);
-     
+
       double beta0 = beta;
-      for (auto tt = 0; tt < tile_fac; ++tt) 
+      for (auto tt = 0; tt < tile_fac; ++tt)
       {
          int ttp1 = tt + 1;
          if (ttp1 < tile_fac) {
@@ -466,7 +468,7 @@ public:
                               stream[ttp1 % 2]);
          }
          stream[tt % 2]->wait();
-        
+
          oneapi::mkl::blas::column_major::gemm(
              *stream[tt % 2], matT, matN, ne, ne, tile_npack2[tt], alpha,
              dev_mem[ia_psi[tt % 2]], tile_npack2[tt], dev_mem[ia_psi[tt % 2]],
@@ -481,27 +483,27 @@ public:
              tile_npack2[tt], beta0, dev_mem[ic22], ne);
          beta0 = 1.0;
       }
-     
+
       stream[0]->memcpy(host_caa, dev_mem[ic11], ne * ne * sizeof(double));
       stream[0]->memcpy(host_cab, dev_mem[ic12], ne * ne * sizeof(double));
       stream[0]->memcpy(host_cbb, dev_mem[ic22], ne * ne * sizeof(double));
-     
+
       stream[0]->wait();
-     
+
       inuse[ic11] = false;
       inuse[ic12] = false;
       inuse[ic22] = false;
    }
- 
+
    /**************************************
     *                                    *
     *              TN1_dgemm             *
     *                                    *
     **************************************/
    /* This function computes  <host_a|host_b> overlap matrix.
- 
+
       host_cab = beta*host_cab + alpha*host_a'*host_b
- 
+
       Entry - npack2,ne: matrix size
       alpha, beta: standard dgemm parameters
       host_a:  (npack2xne) matrix
@@ -512,15 +514,15 @@ public:
       - temporary device memory for (nexne) matrix, ic12.
    */
    void TN1_dgemm(int npack2, int ne, double alpha, double *host_a,
-                  double *host_b, double beta, double *host_cab) 
+                  double *host_b, double beta, double *host_cab)
    {
       int ic12 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
-     
-      if (std::fabs(beta) > 0.0) 
+
+      if (std::fabs(beta) > 0.0)
       {
          stream[0]->memcpy(dev_mem[ic12], host_cab, ne*ne*sizeof(double)).wait();
       }
-     
+
       // copy host_a,host_b --> dev_mem
       syclSetMatrixAsync(tile_npack2[0], ne, sizeof(double),
                          &host_a[tile_start2[0]], npack2, dev_mem[ia_psi[0]],
@@ -528,12 +530,12 @@ public:
       syclSetMatrixAsync(tile_npack2[0], ne, sizeof(double),
                          &host_b[tile_start2[0]], npack2, dev_mem[ia_hpsi[0]],
                          tile_npack2[0], stream[0]);
-     
+
       double beta0 = beta;
-      for (auto tt = 0; tt < tile_fac; ++tt) 
+      for (auto tt = 0; tt < tile_fac; ++tt)
       {
          int ttp1 = tt + 1;
-         if (ttp1 < tile_fac) 
+         if (ttp1 < tile_fac)
          {
             syclSetMatrixAsync(tile_npack2[ttp1], ne, sizeof(double),
                                &host_a[tile_start2[ttp1]], npack2,
@@ -551,25 +553,25 @@ public:
              tile_npack2[tt], beta0, dev_mem[ic12], ne);
          beta0 = 1.0;
       }
-     
+
       stream[0]->memcpy(host_cab, dev_mem[ic12], ne * ne * sizeof(double)).wait();
-     
+
       inuse[ic12] = false;
    }
- 
+
    /**************************************
     *                                    *
     *              NN_dgemm              *
     *                                    *
     **************************************/
    void NN_dgemm(int npack2, int ne, double alpha, double *host_a,
-                 double *host_b, double beta, double *host_c) 
+                 double *host_b, double beta, double *host_c)
    {
       // DGEMM_PWDFT((char *) "N",(char *)
       // "N",npack2,ne,ne,alpha,host_a,npack2,host_b,ne,beta,host_c,npack2);
-     
+
       int ib = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
-     
+
       syclSetMatrixAsync(ne, ne, sizeof(double), host_b, ne, dev_mem[ib], ne, stream[0]);
       syclSetMatrixAsync(tile_npack2[0], ne, sizeof(double),
                          &host_a[tile_start2[0]], npack2, dev_mem[ia_psi[0]],
@@ -577,12 +579,12 @@ public:
       syclSetMatrixAsync(tile_npack2[0], ne, sizeof(double),
                          &host_c[tile_start2[0]], npack2, dev_mem[ia_hpsi[0]],
                          tile_npack2[0], stream[0]);
-     
+
       // double beta0 = beta;
-      for (auto tt = 0; tt < tile_fac; ++tt) 
+      for (auto tt = 0; tt < tile_fac; ++tt)
       {
          int ttp1 = tt + 1;
-         if (ttp1 < tile_fac) 
+         if (ttp1 < tile_fac)
          {
             syclSetMatrixAsync(tile_npack2[ttp1], ne, sizeof(double),
                                &host_a[tile_start2[ttp1]], npack2,
@@ -602,12 +604,12 @@ public:
                             dev_mem[ia_hpsi[tt % 2]], tile_npack2[tt],
                             &host_c[tile_start2[tt]], npack2, stream[tt % 2]);
       }
-     
+
       stream[(tile_fac - 1) % 2]->wait();
-     
+
       inuse[ib] = false;
    }
- 
+
    /**************************************
     *                                    *
     *              NN_dgemm1             *
@@ -618,32 +620,32 @@ public:
                   double *host_a, int lda,
                   double *host_b, int ldb,
                   double beta,
-                  double *host_c,int ldc) 
+                  double *host_c,int ldc)
    {
       int ia = fetch_dev_mem_indx(((size_t)lda) * ((size_t)k));
       int ib = fetch_dev_mem_indx(((size_t)ldb) * ((size_t)n));
       int ic = fetch_dev_mem_indx(((size_t)ldc) * ((size_t)n));
- 
+
       syclSetMatrixAsync(lda,k,sizeof(double),host_a,lda,dev_mem[ia],lda,stream[0]);
       syclSetMatrixAsync(ldb,n,sizeof(double),host_b,ldb,dev_mem[ib],ldb,stream[0]);
- 
+
       stream[0]->wait();
-      oneapi::mkl::blas::column_major::gemm(*stream[0], 
-         matN,matN,m,n,k, 
+      oneapi::mkl::blas::column_major::gemm(*stream[0],
+         matN,matN,m,n,k,
          alpha,
-         dev_mem[ia],lda, 
-         dev_mem[ib],ldb, 
+         dev_mem[ia],lda,
+         dev_mem[ib],ldb,
          beta,
          dev_mem[ic],ldc);
- 
+
       syclGetMatrixAsync(ldc,n,sizeof(double),dev_mem[ic],ldc,host_c,ldc,stream[0]);
       stream[0]->wait();
- 
+
       inuse[ia] = false;
       inuse[ib] = false;
       inuse[ic] = false;
    }
- 
+
    /**************************************
     *                                    *
     *              TN_dgemm2             *
@@ -654,32 +656,32 @@ public:
                   double *host_a, int lda,
                   double *host_b, int ldb,
                   double beta,
-                  double *host_c,int ldc) 
+                  double *host_c,int ldc)
    {
       int ia = fetch_dev_mem_indx(((size_t)lda) * ((size_t)m));
       int ib = fetch_dev_mem_indx(((size_t)ldb) * ((size_t)n));
       int ic = fetch_dev_mem_indx(((size_t)ldc) * ((size_t)n));
- 
+
       syclSetMatrixAsync(lda,m,sizeof(double),host_a,lda,dev_mem[ia],lda,stream[0]);
       syclSetMatrixAsync(ldb,n,sizeof(double),host_b,ldb,dev_mem[ib],ldb,stream[0]);
- 
+
       stream[0]->wait();
-      oneapi::mkl::blas::column_major::gemm(*stream[0], 
-         matT,matN,m,n,k, 
+      oneapi::mkl::blas::column_major::gemm(*stream[0],
+         matT,matN,m,n,k,
          alpha,
-         dev_mem[ia],lda, 
-         dev_mem[ib],ldb, 
+         dev_mem[ia],lda,
+         dev_mem[ib],ldb,
          beta,
          dev_mem[ic],ldc);
- 
+
       syclGetMatrixAsync(ldc,n,sizeof(double),dev_mem[ic],ldc,host_c,ldc,stream[0]);
       stream[0]->wait();
- 
+
       inuse[ia] = false;
       inuse[ib] = false;
       inuse[ic] = false;
    }
- 
+
    /**************************************
     *                                    *
     *              TN_dgemm2c            *
@@ -688,9 +690,9 @@ public:
 /**
   * @brief Performs a specialized matrix multiplication and addition operation.
   *
-  * This function computes the matrix product of host_a (transposed) and host_b, 
-  * multiplies the result by a scalar, and adds the result to host_c. The computation 
-  * is distributed between the CPU and a GPU device for efficiency. The CPU computation 
+  * This function computes the matrix product of host_a (transposed) and host_b,
+  * multiplies the result by a scalar, and adds the result to host_c. The computation
+  * is distributed between the CPU and a GPU device for efficiency. The CPU computation
   * is done using the DGEMM_PWDFT function, while the GPU computation uses the MKL's gemm function.
   *
   * @param n       Number of rows in the resulting matrix.
@@ -701,50 +703,50 @@ public:
   * @param host_b  Pointer to the second input matrix.
   * @param host_c  Pointer to the output matrix. This matrix is also used as an input for the addition operation.
   *
-  * @note The matrices host_a and host_b are transferred to the device asynchronously. 
-  *       The CPU starts its computation immediately after initiating the data transfer to the GPU. 
-  *       Once the GPU computation is complete, the results are added to host_c, which already contains 
+  * @note The matrices host_a and host_b are transferred to the device asynchronously.
+  *       The CPU starts its computation immediately after initiating the data transfer to the GPU.
+  *       Once the GPU computation is complete, the results are added to host_c, which already contains
   *       the results of the CPU computation.
   */
-    void TN_dgemm2c(int n, int m, int npack2, int nida2, double *host_a, double *host_b, double *host_c) 
+    void TN_dgemm2c(int n, int m, int npack2, int nida2, double *host_a, double *host_b, double *host_c)
     {
        constexpr double rtwo  = 2.0;
        constexpr double rone  = 1.0;
        constexpr double rmone = -1.0;
        constexpr double rzero = 0.0;
-      
+
        int ia = fetch_dev_mem_indx(static_cast<size_t>(npack2) * n);
        int ib = fetch_dev_mem_indx(static_cast<size_t>(npack2) * m);
        int ic = fetch_dev_mem_indx(static_cast<size_t>(n) * m);
- 
+
        syclSetMatrixAsync(npack2,n,sizeof(double),host_a,npack2,dev_mem[ia],npack2,stream[0]);
        syclSetMatrixAsync(npack2,m,sizeof(double),host_b,npack2,dev_mem[ib],npack2,stream[0]);
- 
+
        // Start the DGEMM_PWDFT operation on the CPU
-      
+
        stream[0]->wait();
-       oneapi::mkl::blas::column_major::gemm(*stream[0], 
-          matT,matN,n,m,npack2, 
+       oneapi::mkl::blas::column_major::gemm(*stream[0],
+          matT,matN,n,m,npack2,
           rtwo,
-          dev_mem[ia],npack2, 
-          dev_mem[ib],npack2, 
+          dev_mem[ia],npack2,
+          dev_mem[ib],npack2,
           rzero,
           dev_mem[ic],n);
-      
+
        syclGetMatrixAsync(n,m,sizeof(double),dev_mem[ic],n,host_c,n,stream[0]);
        stream[0]->wait();
- 
-       if (nida2 > 0) 
+
+       if (nida2 > 0)
        {
           DGEMM_PWDFT((char *) "T", (char *) "N", n, m, nida2, rmone, host_a, npack2, host_b, npack2, rzero, host_c, n);
        }
- 
+
        inuse[ia] = false;
        inuse[ib] = false;
        inuse[ic] = false;
     }
-    
- 
+
+
    /**************************************
     *                                    *
     *              NT_dgemm3             *
@@ -755,46 +757,46 @@ public:
                   double *host_a, int lda,
                   double *host_b, int ldb,
                   double beta,
-                  double *host_c,int ldc) 
+                  double *host_c,int ldc)
    {
       int ia = fetch_dev_mem_indx(((size_t)lda) * ((size_t)k));
       int ib = fetch_dev_mem_indx(((size_t)ldb) * ((size_t)k));
       int ic = fetch_dev_mem_indx(((size_t)ldc) * ((size_t)n));
- 
+
       syclSetMatrixAsync(lda,k,sizeof(double),host_a,lda,dev_mem[ia],lda,stream[0]);
       syclSetMatrixAsync(ldb,k,sizeof(double),host_b,ldb,dev_mem[ib],ldb,stream[0]);
- 
+
       stream[0]->wait();
-      oneapi::mkl::blas::column_major::gemm(*stream[0], 
-         matN,matT,m,n,k, 
+      oneapi::mkl::blas::column_major::gemm(*stream[0],
+         matN,matT,m,n,k,
          alpha,
-         dev_mem[ia],lda, 
-         dev_mem[ib],ldb, 
+         dev_mem[ia],lda,
+         dev_mem[ib],ldb,
          beta,
          dev_mem[ic],ldc);
- 
+
       syclGetMatrixAsync(ldc,n,sizeof(double),dev_mem[ic],ldc,host_c,ldc,stream[0]);
       stream[0]->wait();
- 
+
       inuse[ia] = false;
       inuse[ib] = false;
       inuse[ic] = false;
    }
- 
- 
+
+
    /**************************************
     *                                    *
     *              TN_dgemm              *
     *                                    *
     **************************************/
    void TN_dgemm(int ne, int nprj, int npack2, double alpha, double *host_a,
-                 double *host_b, double beta, double *host_c) 
+                 double *host_b, double beta, double *host_c)
    {
       // DGEMM_PWDFT((char *) "T",(char *)
       // "N",ne,nprj,npack2,alpha,host_a,npack2,host_b,npack2,beta,host_c,ne);
-     
+
       // gdevice_TN_dgemm(nn,nprj,ng,rtwo,a,b,rzero,sum);
-     
+
       // int ia = fetch_dev_mem_indx(((size_t) npack2) * ((size_t) ne));
       // int ib = fetch_dev_mem_indx(((size_t) npack2) * ((size_t) nprj));
       b_prj = host_b;
@@ -802,10 +804,10 @@ public:
       if (tile_fac > 1)
          ib_prj[1] = fetch_dev_mem_indx(((size_t)tile_npack2_max) * ((size_t)nprj));
       int ic = fetch_dev_mem_indx(((size_t)ne) * ((size_t)nprj));
-     
+
       syclSetMatrixAsync(ne, nprj, sizeof(double), host_c, ne, dev_mem[ic], ne,
                          stream[0]);
-     
+
       if (tile_fac > 1)
          syclSetMatrixAsync(tile_npack2[0], ne, sizeof(double),
                             &a_psi[tile_start2[0]], npack2, dev_mem[ia_psi[0]],
@@ -813,12 +815,12 @@ public:
       syclSetMatrixAsync(tile_npack2[0], nprj, sizeof(double),
                          &b_prj[tile_start2[0]], npack2, dev_mem[ib_prj[0]],
                          tile_npack2[0], stream[0]);
-     
+
       double beta0 = beta;
-      for (auto tt = 0; tt < tile_fac; ++tt) 
+      for (auto tt = 0; tt < tile_fac; ++tt)
       {
          int ttp1 = tt + 1;
-         if (ttp1 < tile_fac) 
+         if (ttp1 < tile_fac)
          {
             syclSetMatrixAsync(tile_npack2[ttp1], ne, sizeof(double),
                                &a_psi[tile_start2[ttp1]], npack2,
@@ -829,7 +831,7 @@ public:
                                dev_mem[ib_prj[ttp1 % 2]], tile_npack2[ttp1],
                                stream[ttp1 % 2]);
          }
-        
+
          stream[tt % 2]->wait();
          oneapi::mkl::blas::column_major::gemm(
              *stream[0], matT, matN, ne, nprj, tile_npack2[tt], alpha,
@@ -838,28 +840,28 @@ public:
          beta0 = 1.0;
       }
       stream[0]->memcpy(host_c, dev_mem[ic], ne * nprj * sizeof(double)).wait();
-     
+
       // inuse[ia] = false;
       // inuse[ib_prj[0]] = false;
       // if (tile_fac>1) inuse[ib_prj[1]] = false;
       inuse[ic] = false;
    }
- 
-   void T_free() 
+
+   void T_free()
    {
       inuse[ib_prj[0]] = false;
       if (tile_fac > 1)
          inuse[ib_prj[1]] = false;
    }
- 
+
    void NT_dgemm(int npack2, int ne, int nprj, double alpha, double *host_a,
-                 double *host_b, double beta, double *host_c) 
+                 double *host_b, double beta, double *host_c)
    {
       // DGEMM_PWDFT((char *) "N",(char *)
       // "T",npack2,ne,nprj,alpha,host_a,npack2,host_b,ne,beta,host_c,npack2);
-     
+
       int ib = fetch_dev_mem_indx(((size_t)ne) * ((size_t)nprj));
-     
+
       syclSetMatrixAsync(ne, nprj, sizeof(double), host_b, ne, dev_mem[ib], ne,
                          stream[(tile_fac - 1) % 2]);
       syclSetMatrixAsync(tile_npack2[tile_fac - 1], ne, sizeof(double),
@@ -870,10 +872,10 @@ public:
                          &host_a[tile_start2[tile_fac - 1]], npack2,
                          dev_mem[ib_prj[(tile_fac - 1) % 2]],
                          tile_npack2[tile_fac - 1], stream[(tile_fac - 1) % 2]);
-      for (auto tt = tile_fac - 1; tt >= 0; --tt) 
+      for (auto tt = tile_fac - 1; tt >= 0; --tt)
       {
          int ttm1 = tt - 1;
-         if (ttm1 >= 0) 
+         if (ttm1 >= 0)
          {
             syclSetMatrixAsync(tile_npack2[ttm1], ne, sizeof(double),
                                &host_c[tile_start2[ttm1]], npack2,
@@ -893,20 +895,20 @@ public:
                             dev_mem[ia_hpsi[tt % 2]], tile_npack2[tt],
                             &host_c[tile_start2[tt]], npack2, stream[tt % 2]);
       }
-     
+
       inuse[ib] = false;
       inuse[ib_prj[0]] = false;
       if (tile_fac > 1)
          inuse[ib_prj[1]] = false;
    }
- 
+
    /**************************************
     *                                    *
     *              MM6_dgemm             *
     *                                    *
     **************************************/
    void MM6_dgemm(int ne, double *host_s21, double *host_s12, double *host_s11,
-                  double *host_sa0, double *host_sa1, double *host_st1) 
+                  double *host_sa0, double *host_sa1, double *host_st1)
    {
       double rzero = 0.0;
       double rone = 1.0;
@@ -916,31 +918,31 @@ public:
       int i_sa0 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne)); // input
       int i_st1 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne)); // tmp
       int i_sa1 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne)); // input-output
-     
+
       syclSetMatrixAsync(ne, ne, sizeof(double), host_s21, ne, dev_mem[i_s21], ne, stream[0]);
       syclSetMatrixAsync(ne, ne, sizeof(double), host_sa0, ne, dev_mem[i_sa0], ne, stream[0]);
       syclSetMatrixAsync(ne, ne, sizeof(double), host_sa1, ne, dev_mem[i_sa1], ne, stream[0]);
-     
+
       syclSetMatrixAsync(ne, ne, sizeof(double), host_s12, ne, dev_mem[i_s12], ne, stream[1]);
       syclSetMatrixAsync(ne, ne, sizeof(double), host_s11, ne, dev_mem[i_s11], ne, stream[1]);
-     
+
       // mmm_Multiply(ms, s21, sa0, 1.0, sa1, 1.0);
       stream[0]->wait();
       oneapi::mkl::blas::column_major::gemm(
           *stream[0], matN, matN, ne, ne, ne, rone, dev_mem[i_s21], ne,
           dev_mem[i_sa0], ne, rone, dev_mem[i_sa1], ne);
-     
+
       // mmm_Multiply(ms, sa0, s12, 1.0, sa1, 1.0);
       stream[1]->wait();
       oneapi::mkl::blas::column_major::gemm(
           *stream[1], matN, matN, ne, ne, ne, rone, dev_mem[i_sa0], ne,
           dev_mem[i_s12], ne, rone, dev_mem[i_sa1], ne);
-     
+
       // mmm_Multiply(ms, s11, sa0, 1.0, st1, 0.0);
       oneapi::mkl::blas::column_major::gemm(
           *stream[1], matN, matN, ne, ne, ne, rone, dev_mem[i_s11], ne,
           dev_mem[i_sa0], ne, rzero, dev_mem[i_st1], ne);
-     
+
       // mmm_Multiply(ms, sa0, st1, 1.0, sa1, 1.0);
       oneapi::mkl::blas::column_major::gemm(
           *stream[1], matN, matN, ne, ne, ne, rone, dev_mem[i_sa0], ne,
@@ -948,7 +950,7 @@ public:
       syclGetMatrixAsync(ne, ne, sizeof(double), dev_mem[i_sa1], ne, host_sa1, ne,
                          stream[1]);
       stream[1]->wait();
-     
+
       inuse[i_s21] = false;
       inuse[i_s12] = false;
       inuse[i_s11] = false;
@@ -958,8 +960,8 @@ public:
    }
 
 
-
-   void CN1_zgemm(int npack2, int ne, double *alpha, double *host_a,
+   // RAY: Added npack
+   void CN1_zgemm(int npack2, int npack, int ne, double *alpha, double *host_a,
                   double *host_b, double *beta, double *host_cab)
    {
       int ic12 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
@@ -1213,21 +1215,213 @@ public:
       inuse[ic] = false;
    }
 
+   // RAY I added this function: it needs to be checked
+   void CN3_zgemm(int npack1, int npack2, int ne, double *alpha, double *host_a,
+                  double *host_b, double *beta, double *host_caa, double* host_cab,
+                  double *host_cbb)
+   {
+    int ic11 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
+    int ic12 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
+    int ic21 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
+    int ic22 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
+
+    if (std::fabs(*beta) > 0.0)
+    {
+        stream[0]->memcpy(dev_mem[ic11], host_caa, ne * ne * sizeof(double));
+        stream[0]->memcpy(dev_mem[ic12], host_cab, ne * ne * sizeof(double));
+        stream[0]->memcpy(dev_mem[ic22], host_cbb, ne * ne * sizeof(double));
+    }
+
+    // copy host_a,host_b --> dev_mem
+    syclSetMatrixAsync(tile_npack2[0], ne, sizeof(double),
+                       &host_a[tile_start2[0]], npack2, dev_mem[ia_psi[0]],
+                       tile_npack2[0], stream[0]);
+    syclSetMatrixAsync(tile_npack2[0], ne, sizeof(double),
+                       &host_b[tile_start2[0]], npack2, dev_mem[ia_hpsi[0]],
+                       tile_npack2[0], stream[0]);
+
+    double beta0 = *beta;
+    for (auto tt = 0; tt < tile_fac; ++tt)
+    {
+        int ttp1 = tt + 1;
+        if (ttp1 < tile_fac)
+        {
+            syclSetMatrixAsync(tile_npack2[ttp1], ne, sizeof(double),
+                               &host_a[tile_start2[ttp1]], npack2,
+                               dev_mem[ia_psi[ttp1 % 2]], tile_npack2[ttp1],
+                               stream[ttp1 % 2]);
+            syclSetMatrixAsync(tile_npack2[ttp1], ne, sizeof(double),
+                               &host_b[tile_start2[ttp1]], npack2,
+                               dev_mem[ia_hpsi[ttp1 % 2]], tile_npack2[ttp1],
+                               stream[ttp1 % 2]);
+        }
+        stream[tt % 2]->wait();
+
+        oneapi::mkl::blas::column_major::gemm(
+            *stream[tt % 2], matT, matN, ne, ne, tile_npack2[tt], *alpha,
+            dev_mem[ia_psi[tt % 2]], tile_npack2[tt], dev_mem[ia_psi[tt % 2]],
+            tile_npack2[tt], beta0, dev_mem[ic11], ne);
+        oneapi::mkl::blas::column_major::gemm(
+            *stream[tt % 2], matT, matN, ne, ne, tile_npack2[tt], *alpha,
+            dev_mem[ia_psi[tt % 2]], tile_npack2[tt], dev_mem[ia_hpsi[tt % 2]],
+            tile_npack2[tt], beta0, dev_mem[ic12], ne);
+        oneapi::mkl::blas::column_major::gemm(
+            *stream[tt % 2], matT, matN, ne, ne, tile_npack2[tt], *alpha,
+            dev_mem[ia_hpsi[tt % 2]], tile_npack2[tt], dev_mem[ia_hpsi[tt % 2]],
+            tile_npack2[tt], beta0, dev_mem[ic22], ne);
+        beta0 = 1.0;
+    }
+
+    stream[0]->memcpy(host_caa, dev_mem[ic11], ne * ne * sizeof(double));
+    stream[0]->memcpy(host_cab, dev_mem[ic12], ne * ne * sizeof(double));
+    stream[0]->memcpy(host_cbb, dev_mem[ic22], ne * ne * sizeof(double));
+
+    stream[0]->wait();
+
+    inuse[ic11] = false;
+    inuse[ic12] = false;
+    inuse[ic22] = false;
+   }
+
+   // RAY I added this function: it needs to be checked
+   void CN4_zgemm(int npack1, int npack2, int ne, double *alpha, double *host_a,
+                  double *host_b, double *beta, double *host_caa,
+                  double *host_cab, double *host_cba, double *host_cbb)
+   {
+    int ic11 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
+    int ic12 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
+    int ic21 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
+    int ic22 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne));
+
+    if (std::fabs(*beta) > 0.0)
+    {
+        stream[0]->memcpy(dev_mem[ic11], host_caa, ne * ne * sizeof(double));
+        stream[0]->memcpy(dev_mem[ic12], host_cab, ne * ne * sizeof(double));
+        stream[0]->memcpy(dev_mem[ic21], host_cba, ne * ne * sizeof(double));
+        stream[0]->memcpy(dev_mem[ic22], host_cbb, ne * ne * sizeof(double));
+    }
+
+    // copy host_a,host_b --> dev_mem
+    syclSetMatrixAsync(tile_npack2[0], ne, sizeof(double),
+                       &host_a[tile_start2[0]], npack2, dev_mem[ia_psi[0]],
+                       tile_npack2[0], stream[0]);
+    syclSetMatrixAsync(tile_npack2[0], ne, sizeof(double),
+                       &host_b[tile_start2[0]], npack2, dev_mem[ia_hpsi[0]],
+                       tile_npack2[0], stream[0]);
+
+    double beta0 = *beta;
+    for (auto tt = 0; tt < tile_fac; ++tt)
+    {
+        int ttp1 = tt + 1;
+        if (ttp1 < tile_fac)
+        {
+            syclSetMatrixAsync(tile_npack2[ttp1], ne, sizeof(double),
+                               &host_a[tile_start2[ttp1]], npack2,
+                               dev_mem[ia_psi[ttp1 % 2]], tile_npack2[ttp1],
+                               stream[ttp1 % 2]);
+            syclSetMatrixAsync(tile_npack2[ttp1], ne, sizeof(double),
+                               &host_b[tile_start2[ttp1]], npack2,
+                               dev_mem[ia_hpsi[ttp1 % 2]], tile_npack2[ttp1],
+                               stream[ttp1 % 2]);
+        }
+        stream[tt % 2]->wait();
+
+        oneapi::mkl::blas::column_major::gemm(
+            *stream[tt % 2], matT, matN, ne, ne, tile_npack2[tt], *alpha,
+            dev_mem[ia_psi[tt % 2]], tile_npack2[tt], dev_mem[ia_psi[tt % 2]],
+            tile_npack2[tt], beta0, dev_mem[ic11], ne);
+        oneapi::mkl::blas::column_major::gemm(
+            *stream[tt % 2], matT, matN, ne, ne, tile_npack2[tt], *alpha,
+            dev_mem[ia_psi[tt % 2]], tile_npack2[tt], dev_mem[ia_hpsi[tt % 2]],
+            tile_npack2[tt], beta0, dev_mem[ic12], ne);
+        oneapi::mkl::blas::column_major::gemm(
+            *stream[tt % 2], matT, matN, ne, ne, tile_npack2[tt], *alpha,
+            dev_mem[ia_hpsi[tt % 2]], tile_npack2[tt], dev_mem[ia_psi[tt % 2]],
+            tile_npack2[tt], beta0, dev_mem[ic21], ne);
+        oneapi::mkl::blas::column_major::gemm(
+            *stream[tt % 2], matT, matN, ne, ne, tile_npack2[tt], *alpha,
+            dev_mem[ia_hpsi[tt % 2]], tile_npack2[tt], dev_mem[ia_hpsi[tt % 2]],
+            tile_npack2[tt], beta0, dev_mem[ic22], ne);
+        beta0 = 1.0;
+    }
+
+    stream[0]->memcpy(host_caa, dev_mem[ic11], ne * ne * sizeof(double));
+    stream[0]->memcpy(host_cab, dev_mem[ic12], ne * ne * sizeof(double));
+    stream[0]->memcpy(host_cba, dev_mem[ic21], ne * ne * sizeof(double));
+    stream[0]->memcpy(host_cbb, dev_mem[ic22], ne * ne * sizeof(double));
+
+    stream[0]->wait();
+
+    inuse[ic11] = false;
+    inuse[ic12] = false;
+    inuse[ic21] = false;
+    inuse[ic22] = false;
+
+   }
+
+   // RAY I added this function: it needs to be checked
+   void WW6_zgemm(int ne, double *host_s21, double *host_s12, double *host_s11,
+                  double *host_sa0, double *host_sa1, double *host_st1)
+   {
+      double rone = 1.0;
+      double rzero = 0.0;
+      int i_s21 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne)); // input
+      int i_s12 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne)); // input
+      int i_s11 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne)); // input
+      int i_sa0 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne)); // input
+      int i_st1 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne)); // tmp
+      int i_sa1 = fetch_dev_mem_indx(((size_t)ne) * ((size_t)ne)); // input-output
+
+      syclSetMatrixAsync(ne, ne, sizeof(double), host_s21, ne, dev_mem[i_s21], ne, stream[0]);
+      syclSetMatrixAsync(ne, ne, sizeof(double), host_sa0, ne, dev_mem[i_sa0], ne, stream[0]);
+      syclSetMatrixAsync(ne, ne, sizeof(double), host_sa1, ne, dev_mem[i_sa1], ne, stream[0]);
+
+      syclSetMatrixAsync(ne, ne, sizeof(double), host_s12, ne, dev_mem[i_s12], ne, stream[1]);
+      syclSetMatrixAsync(ne, ne, sizeof(double), host_s11, ne, dev_mem[i_s11], ne, stream[1]);
+
+      // www_Multiply(ms, s21, sa0, 1.0, sa1, 1.0);
+      stream[0]->wait();
+      oneapi::mkl::blas::column_major::gemm(  // ERROR
+          *stream[0], matN, matN, ne, ne, ne, rone, dev_mem[i_s21], ne,
+          dev_mem[i_sa0], ne, rone, dev_mem[i_sa1], ne);
+
+      // www_Multiply(ms, sa0, s12, 1.0, sa1, 1.0);
+      stream[1]->wait();
+      oneapi::mkl::blas::column_major::gemm( // ERROR
+          *stream[1], matT, matN, ne, ne, ne, rone, dev_mem[i_sa0], ne,
+          dev_mem[i_s12], ne, rone, dev_mem[i_sa1], ne);
+
+      // www_Multiply(ms, s11, sa0, 1.0, st1, 0.0);
+      oneapi::mkl::blas::column_major::gemm( // ERROR
+          *stream[1], matN, matT, ne, ne, ne, rone, dev_mem[i_s11], ne,
+          dev_mem[i_sa0], ne, rzero, dev_mem[i_st1], ne);
+
+      // www_Multiply(ms, sa0, st1, 1.0, sa1, 1.0);
+      oneapi::mkl::blas::column_major::gemm( // ERROR
+          *stream[1], matN, matN, ne, ne, ne, rone, dev_mem[i_sa0], ne,
+          dev_mem[i_st1], ne, rone, dev_mem[i_sa1], ne);
+
+      syclGetMatrixAsync(ne, ne, sizeof(double), dev_mem[i_sa1], ne, host_sa1, ne,
+                         stream[1]);
+      stream[1]->wait();
+
+      inuse[i_s21] = false;
+      inuse[i_s12] = false;
+      inuse[i_s11] = false;
+      inuse[i_sa0] = false;
+      inuse[i_st1] = false;
+      inuse[i_sa1] = false;
+   }
 
 
 
-
-
-
-
- 
    /********************/
    /* psi_dev functions*/
    /********************/
-   void psi_alloc(int npack1, int ne, int tile_fac0 = 1) 
+   void psi_alloc(int npack1, int ne, int tile_fac0 = 1)
    {
       tile_fac = tile_fac0;
-     
+
       tile_npack2_max = (((2 * npack1) % tile_fac) == 0)
                             ? (2 * npack1) / tile_fac
                             : (2 * npack1) / tile_fac + 1;
@@ -1237,15 +1431,15 @@ public:
          tile_npack2[i] = (2 * npack1) / tile_fac;
       for (auto i = 0; i < ((2 * npack1) % tile_fac); ++i)
          tile_npack2[i] += 1;
-     
+
       tile_start2[0] = 0;
       for (auto i = 1; i < tile_fac; ++i)
          tile_start2[i] = tile_start2[i - 1] + tile_npack2[i - 1];
-     
+
       ia_psi[0] = fetch_dev_mem_indx(((size_t)tile_npack2_max) * ((size_t)ne));
       ia_hpsi[0] = fetch_dev_mem_indx(((size_t)tile_npack2_max) * ((size_t)ne));
-     
-      if (tile_fac > 1) 
+
+      if (tile_fac > 1)
       {
          ia_psi[1] = fetch_dev_mem_indx(((size_t)tile_npack2_max) * ((size_t)ne));
          ia_hpsi[1] = fetch_dev_mem_indx(((size_t)tile_npack2_max) * ((size_t)ne));
@@ -1253,25 +1447,25 @@ public:
       if (DEBUG_IO) std::cout << "Into psi_alloc, tile_factor = " << tile_fac << " ndev_mem=" << ndev_mem << std::endl;
    }
 
-   void psi_dealloc() 
+   void psi_dealloc()
    {
       inuse[ia_psi[0]] = false;
       inuse[ia_hpsi[0]] = false;
-      if (tile_fac > 1) 
+      if (tile_fac > 1)
       {
          inuse[ia_psi[1]] = false;
          inuse[ia_hpsi[1]] = false;
       }
    }
 
-   void psi_copy_host2gpu(int npack1, int ne, double *psi) 
+   void psi_copy_host2gpu(int npack1, int ne, double *psi)
    {
       a_psi = psi;
       syclSetMatrixAsync(tile_npack2[0], ne, sizeof(double), psi, 2 * npack1,
                          dev_mem[ia_psi[0]], tile_npack2[0], stream[0]);
    }
 
-   void hpsi_copy_host2gpu(int npack1, int ne, double *hpsi) 
+   void hpsi_copy_host2gpu(int npack1, int ne, double *hpsi)
    {
       int tt = tile_fac - 1;
       a_hpsi = hpsi;
@@ -1280,9 +1474,9 @@ public:
           dev_mem[ia_hpsi[tt % 2]], tile_npack2[tt], stream[tt % 2]);
    }
 
-   void psi_copy_gpu2host(int npack1, int ne, double *psi) 
+   void psi_copy_gpu2host(int npack1, int ne, double *psi)
    {
-      if (tile_fac == 1) 
+      if (tile_fac == 1)
       {
          stream[0]->wait();
          syclGetMatrixAsync(tile_npack2[0], ne, sizeof(double), dev_mem[ia_psi[0]],
@@ -1290,14 +1484,14 @@ public:
       }
    }
 
-   void hpsi_copy_gpu2host(int npack1, int ne, double *hpsi) 
+   void hpsi_copy_gpu2host(int npack1, int ne, double *hpsi)
    {
       stream[0]->wait();
    }
 
- 
+
    /* fft functions*/
-   int batch_fft_init(int nx, int ny, int nz, int nq1, int nq2, int nq3) 
+   int batch_fft_init(int nx, int ny, int nz, int nq1, int nq2, int nq3)
    {
        /*
       desc_x[fftcount] = new desc_real_t(nx);
@@ -1305,79 +1499,79 @@ public:
                         nq1);
       desc_x[fftcount]->set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, nx + 2);
       desc_x[fftcount]->set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, nx/2 + 1);
-     
+
       desc_y[fftcount] = new desc_cmplx_t(ny);
       desc_y[fftcount]->set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS,
                         nq2);
       desc_y[fftcount]->set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, ny);
       desc_y[fftcount]->set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, ny);
-     
+
       desc_z[fftcount] = new desc_cmplx_t(nz);
       desc_z[fftcount]->set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS,
                         nq3);
       desc_z[fftcount]->set_value(oneapi::mkl::dft::config_param::FWD_DISTANCE, nz);
       desc_z[fftcount]->set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, nz);
-     
+
       desc_x[fftcount]->commit(*stream[0]);
       desc_y[fftcount]->commit(*stream[0]);
       desc_z[fftcount]->commit(*stream[0]);
-     
+
       int tag = fftcount;
       ++fftcount;
-     
+
       return tag;
       */
    }
- 
- 
+
+
    void batch_fft_pipeline_mem_init(const int nstages, const int n2ft3d) {
     //  ifft_n = nstages;
- 
+
    //   // allocate memory and cuda streams
    //   for (auto i=0; i<ifft_n; ++i)
    //      ifft_dev[i] = fetch_dev_mem_indx(((size_t)n2ft3d));
    }
- 
- 
- 
+
+
+
    void batch_fft_end(const int tag) {
     // delete desc_x[tag];
     // delete desc_y[tag];
     // delete desc_z[tag];
     // --fftcount;
- 
+
      //ndev_mem = 0;
    }
 
 
-  
+
    void batch_rfftx_tmpx(bool forward, int nx, int nq, int n2ft3d, double *a, double *tmpx)
-   {                                 
+   {
       int nxh2 = nx + 2;
       if (forward)
       {
          int indx = 0;
-         for (auto q = 0; q < nq; ++q)                                         
-         {                                                                     
-            drfftf_(&nx, a + indx, tmpx);                                      
+         for (auto q = 0; q < nq; ++q)
+         {
+            drfftf_(&nx, a + indx, tmpx);
             indx += nxh2;
          }
          indx = 1;
          for (auto j = 0; j < (nq); ++j)
          {
-            for (auto i = nx; i >= 2; --i)                                     
+            for (auto i = nx; i >= 2; --i)
             {
-               a[indx + i - 1] = a[indx + i - 2];                              
+               a[indx + i - 1] = a[indx + i - 2];
             }
             a[indx + 1 - 1] = 0.0;
             a[indx + nx + 1 - 1] = 0.0;
             indx += nxh2;
-         }                                                                     
-      }                                                                        
+         }
+      }
       else
       {
          int indx = 1;
-         for (auto j = 0; j < nq; ++j)                                         
+         for (auto j = 0; j < nq; ++j)
          {
             for (auto i = 2; i <= nx; ++i)
                a[indx + i - 2] = a[indx + i - 1];
@@ -1414,7 +1608,7 @@ public:
          }
       }
    }
- 
+
    void batch_cffty_tmpy(bool forward, int ny, int nq, int n2ft3d, double *a, double *tmpy)
    {
       if (forward)
@@ -1436,8 +1630,8 @@ public:
          }
       }
    }
- 
- 
+
+
    void batch_cffty_tmpy_zero(bool forward, int ny, int nq, int n2ft3d, double *a, double *tmpy, bool *zero)
    {
       if (forward)
@@ -1461,33 +1655,33 @@ public:
          }
       }
    }
- 
- 
- 
- 
-   void batch_cfftz_tmpz(bool forward, int nz, int nq, int n2ft3d, double *a, double *tmpz) 
+
+
+
+
+   void batch_cfftz_tmpz(bool forward, int nz, int nq, int n2ft3d, double *a, double *tmpz)
    {
-      if (forward) 
+      if (forward)
       {
          int indx = 0;
-         for (auto q = 0; q < nq; ++q) 
+         for (auto q = 0; q < nq; ++q)
          {
             dcfftf_(&nz, a + indx, tmpz);
             indx += (2 * nz);
          }
-      } 
-      else 
+      }
+      else
       {
          int indx = 0;
-         for (auto q = 0; q < nq; ++q) 
+         for (auto q = 0; q < nq; ++q)
          {
             dcfftb_(&nz, a + indx, tmpz);
             indx += (2 * nz);
          }
       }
    }
- 
- 
+
+
    void batch_cfftz_tmpz_zero(bool forward, int nz, int nq, int n2ft3d, double *a, double *tmpz, bool *zero)
    {
       if (forward)
@@ -1511,35 +1705,35 @@ public:
          }
       }
    }
- 
- 
-   
- 
- 
- 
+
+
+
+
+
+
    // routines below need to be made into sycl or removed
- 
-   static void eigsrt_device(double *D, double *V, int n) 
+
+   static void eigsrt_device(double *D, double *V, int n)
    {
       int i, j, k;
       double p;
-     
-      for (i = 0; i < (n - 1); ++i) 
+
+      for (i = 0; i < (n - 1); ++i)
       {
          k = i;
          p = D[i];
          for (j = i + 1; j < n; ++j)
-            if (D[j] >= p) 
+            if (D[j] >= p)
             {
                k = j;
                p = D[j];
             }
-        
-         if (k != i) 
+
+         if (k != i)
          {
             D[k] = D[i];
             D[i] = p;
-            for (j = 0; j < n; ++j) 
+            for (j = 0; j < n; ++j)
             {
                p = V[j + i * n];
                V[j + i * n] = V[j + k * n];
@@ -1549,26 +1743,26 @@ public:
       }
    }
 
- 
-   void NN_eigensolver(int ispin, int ne[], double *host_hml, double *host_eig) 
+
+   void NN_eigensolver(int ispin, int ne[], double *host_hml, double *host_eig)
    {
       int n, ierr;
       int nn = ne[0] * ne[0] + 14;
       double xmp1[nn];
       // double *xmp1 = new (std::nothrow) double[nn]();
-     
+
       int shift1 = 0;
       int shift2 = 0;
-      for (int ms = 0; ms < ispin; ++ms) 
+      for (int ms = 0; ms < ispin; ++ms)
       {
          n = ne[ms];
-        
+
          // eigen_(&n,&n,&hml[shift2],&eig[shift1],xmp1,&ierr);
          //  d3db::parall->Barrier();
          EIGEN_PWDFT(n, host_hml + shift2, host_eig + shift1, xmp1, nn, ierr);
          // if (ierr != 0) throw std::runtime_error(std::string("NWPW Error:
          // EIGEN_PWDFT failed!"));
-        
+
          eigsrt_device(host_eig + shift1, host_hml + shift2, n);
          shift1 += ne[0];
          shift2 += ne[0] * ne[0];
@@ -1576,20 +1770,20 @@ public:
    }
 
 
-   void WW_eigensolver(int ispin, int ne[], double *host_hml, double *host_eig) 
+   void WW_eigensolver(int ispin, int ne[], double *host_hml, double *host_eig)
    {
       int n, ierr;
       int nn = ne[0] * ne[0] + 14;
       double xmp1[nn];
       double rmp1[nn];
       // double *xmp1 = new (std::nothrow) double[nn]();
-     
+
       int shift1 = 0;
       int shift2 = 0;
-      for (int ms=0; ms<ispin; ++ms) 
+      for (int ms=0; ms<ispin; ++ms)
       {
          n = ne[ms];
-        
+
          // eigen_(&n,&n,&hml[shift2],&eig[shift1],xmp1,&ierr);
          //  d3db::parall->Barrier();
          MKL_Complex16* hml = reinterpret_cast<MKL_Complex16*>(host_hml+shift2);
@@ -1598,11 +1792,11 @@ public:
          //ZEIGEN_PWDFT(n, host_hml + shift2, host_eig + shift1, xmp1, nn, rmp1, ierr);
          // if (ierr != 0) throw std::runtime_error(std::string("NWPW Error:
          // EIGEN_PWDFT failed!"));
-       
+
          //eigsrt_device(host_eig + shift1, host_hml + shift2, n);
          shift1 += 2*ne[0];
          shift2 += 4*ne[0]*ne[0];
-      } 
+      }
    }
 
 


### PR DESCRIPTION
I have added some functions that were missing in `gdevices_sycl.hpp` at the time of compilation. These are mainly `CN3`, `CN4`, and `WW6`. The `CN1` function was missing a parameter, I also added it. Based on the structure and logic of the same functions that are in C/C++, but adapting them to the sycl logic. These modifications allow me to compile the code and run it. When doing some tests with the QA/BAND examples I get runtime errors. Could you take a look at it? @ebylaska 