### PR TITLE
variable defined at argument PWDFT/Nwpw/nwpwlib/device/gdevices_sycl.hpp:2221 `int n`

### DIFF
--- a/Nwpw/nwpwlib/device/gdevices_sycl.hpp
+++ b/Nwpw/nwpwlib/device/gdevices_sycl.hpp
@@ -2218,7 +2218,7 @@ public:
     **************************************/
    void NN_eigensolver0(int n, double *host_hml, double *host_eig)
    {
-      int n, ierr;
+      int ierr;
       int nn = n*n + 14;
       double xmp1[nn];
 


### PR DESCRIPTION
fixing very simple compilation error